### PR TITLE
Revert to using 64-bit precision.

### DIFF
--- a/src/skillmodels/maximization_inputs.py
+++ b/src/skillmodels/maximization_inputs.py
@@ -15,7 +15,7 @@ from skillmodels.process_data import process_data
 from skillmodels.process_debug_data import process_debug_data
 from skillmodels.process_model import process_model
 
-jax.config.update("jax_enable_x64", False)  # noqa: FBT003
+jax.config.update("jax_enable_x64", True)  # noqa: FBT003
 
 
 def get_maximization_inputs(model_dict, data):


### PR DESCRIPTION
Had changed this setting to False / 32-bit precision when attempting to reduce memory consumption. Looks like this was responsible for some jax overflow issues in a reasonably-sized project.

Not quite worth a PR, ofc, but important and should not be part of other imminent changes.